### PR TITLE
Scrum 83 badges ins readme einfugen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 22
 
       - name: Install dependencies
-        run: npm ci # maybe use npm install?
+        run: npm ci
 
       - name: Linting - Run ESLint
         run: npm run lint -- --max-warnings=0
@@ -29,5 +29,10 @@ jobs:
       - name: Run build
         run: npm run build --if-present
 
-      - name: Run tests
-        run: npm test
+      - name: Run tests with coverage
+        run: npm run coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          directory: ./multiarm-bandit/coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
-          directory: ./multiarm-bandit/coverage
+          files: ./multiarm-bandit/coverage/coverage-final.json
+          flags: unittests
+          name: codecov-coverage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# programming-project-bandit
+# Multiarm Bandit - programming-project
 
-test test
-Hallo
-
-demonstration
+[![CI - Build Status](https://github.com/marcowolters91/programming-project-bandit/actions/workflows/ci.yml/badge.svg)](https://github.com/marcowolters91/programming-project-bandit/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/marcowolters91/programming-project-bandit/branch/main/graph/badge.svg)](https://codecov.io/gh/marcowolters91/programming-project-bandit)

--- a/multiarm-bandit/vitest.config.js
+++ b/multiarm-bandit/vitest.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
     environment: "jsdom",
     include: ["tests/**/*.test.js"],
     coverage: {
-      reporter: ["text", "html"], 
+      reporter: ["text", "html", "json"], 
       reportsDirectory: "./coverage",
       provider: "v8",
     },


### PR DESCRIPTION
CI- und Coverage-Badges ins README eingefügt

- Build-Status-Badge (GitHub Actions) ins README.md im Root-Verzeichnis eingefügt
- Test-Coverage-Badge hinzugefügt - externen Service Codecov dafür ans Repo angebunden
- Sicher gestellt, dass die Badges direkt auf der Repository-Startseite sichtbar sind
- Aufräumen von doppelten/überflüssigen Readme-Dateien in .github/